### PR TITLE
wbd export command fix

### DIFF
--- a/x/currencies/module.go
+++ b/x/currencies/module.go
@@ -113,5 +113,5 @@ func (app AppModule) InitGenesis(ctx sdk.Context, data json.RawMessage) []abci.V
 
 // Export genesis.
 func (app AppModule) ExportGenesis(ctx sdk.Context) json.RawMessage {
-	return json.RawMessage{}
+	return nil
 }

--- a/x/multisig/module.go
+++ b/x/multisig/module.go
@@ -114,5 +114,5 @@ func (app AppModule) InitGenesis(ctx sdk.Context, data json.RawMessage) []abci.V
 
 // Export genesis.
 func (app AppModule) ExportGenesis(ctx sdk.Context) json.RawMessage {
-	return json.RawMessage{}
+	return nil
 }

--- a/x/vm/module.go
+++ b/x/vm/module.go
@@ -137,5 +137,5 @@ func (app AppModule) InitGenesis(ctx sdk.Context, data json.RawMessage) []abci.V
 // In my opinion we shouldn't export anything, as we can't predict what initially in write set, and how storage
 // resources could be changed during contracts executions.
 func (app AppModule) ExportGenesis(ctx sdk.Context) json.RawMessage {
-	return json.RawMessage{}
+	return nil
 }


### PR DESCRIPTION
Fix for failing "wbd export" command

Tested:
1. Before node was started ("State is not initialized. Returning genesis file.");
2. After node was started (wbd start);