### PR TITLE
version support in wbd and wbcli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,28 @@ PROTO_OUT_DS_DIR=./x/vm/internal/types/ds_grpc/
 PROTOBUF_VM_FILES=./vm-proto/protos/vm.proto
 PROTOBUF_DS_FILES=./vm-proto/protos/data-source.proto
 
-all: protos install
-install: protos go.sum
-		GO111MODULE=on go install -tags "$(build_tags)" ./cmd/wbd
-		GO111MODULE=on go install -tags "$(build_tags)" ./cmd/wbcli
+git_tag=$(shell git describe --tags $(git rev-list --tags --max-count=1))
+git_commit=$(shell git rev-list -1 HEAD)
+tags = -X github.com/cosmos/cosmos-sdk/version.Name=wb \
+	   -X github.com/cosmos/cosmos-sdk/version.ServerName=wbd \
+	   -X github.com/cosmos/cosmos-sdk/version.ClientName=wbcli \
+	   -X github.com/cosmos/cosmos-sdk/version.Commit=$(git_commit) \
+	   -X github.com/cosmos/cosmos-sdk/version.Version=${git_tag} \
+
+all: install
+install: protos go.sum install-wbd install-wbcli install-oracleapp
+
+install-wbd:
+		GO111MODULE=on go install --ldflags "$(tags)"  -tags "$(build_tags)" ./cmd/wbd
+install-wbcli:
+		GO111MODULE=on go install  --ldflags "$(tags)"  -tags "$(build_tags)" ./cmd/wbcli
+install-oracleapp:
 		GO111MODULE=on go install -tags "$(build_tags)" ./cmd/oracle-app
+
 go.sum: go.mod
 		@echo "--> Ensure dependencies have not been modified"
 		GO111MODULE=on go mod verify
+
 protos:
 	mkdir -p ${PROTO_OUT_VM_DIR}
 	mkdir -p ${PROTO_OUT_DS_DIR}

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ So after this command both `wbd` and `wbcli` will be available from console
     wbd version --long
     wbcli version --long
 
+If you want to install specific application (not everything), you always can do:
+
+    make protos install-wbd
+    make protos install-wbcli
+    make protos install-oracleapp
+
 # Usage
 
 First of all we need to create genesis configuration and name of node:

--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ Both commands must execute fine, after it you can run both daemon and cli:
 
 To install both cli and daemon as binaries you can use Makefile:
 
-    make install
+    make install 
 
-So after this command both `wbd` and `wbcli` will be available from console.
+So after this command both `wbd` and `wbcli` will be available from console
+
+    wbd version --long
+    wbcli version --long
 
 # Usage
 


### PR DESCRIPTION
Now support version command for wbd and wcli, e.g. `wbd version --long`. 
Make command 'make install' takes latest commit and current tag during execution, and put it into build.

Also supports install for separated applications.