### PR TITLE
ability to set address of compiler via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,15 @@ It should be done before next commands, so see tutorial **[how to initialize gen
     wbd add-genesis-poa-validator [validator-2-address] [validator-2-eth-address]
     wbd add-genesis-poa-validator [validator-3-address] [validator-3-eth-address]
 
-Replace expressions in brackets with correct addresses, include Ethereum addresses, configure chain by Cosmos SDK documentation:
+Replace expressions in brackets with correct addresses, include Ethereum addresses.
+
+Now configure cli:
 
     wbcli config chain-id wings-testnet
     wbcli config output json
     wbcli config indent true
     wbcli config trust-node true
+    wbcli config compiler 127.0.0.1:50053
 
 Time to change denom in PoS configuration.
 So open `~/.wbd/config/genesis.json` and find this stake settings:

--- a/cmd/config/cli_config.go
+++ b/cmd/config/cli_config.go
@@ -1,0 +1,166 @@
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+
+	toml "github.com/pelletier/go-toml"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+)
+
+const (
+	flagGet = "get"
+)
+
+var configDefaults = map[string]string{
+	"chain-id":       "",
+	"output":         "text",
+	"node":           "tcp://localhost:26657",
+	"broadcast-mode": "sync",
+	"compiler":       "127.0.0.1:50053",
+}
+
+// ConfigCmd returns a CLI command to interactively create an application CLI
+// config file.
+func ConfigCmd(defaultCLIHome string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config <key> [value]",
+		Short: "Create or query an application CLI configuration file",
+		RunE:  runConfigCmd,
+		Args:  cobra.RangeArgs(0, 2),
+	}
+
+	cmd.Flags().String(flags.FlagHome, defaultCLIHome,
+		"set client's home directory for configuration")
+	cmd.Flags().Bool(flagGet, false,
+		"print configuration value or its default if unset")
+	return cmd
+}
+
+func runConfigCmd(cmd *cobra.Command, args []string) error {
+	cfgFile, err := ensureConfFile(viper.GetString(flags.FlagHome))
+	if err != nil {
+		return err
+	}
+
+	getAction := viper.GetBool(flagGet)
+	if getAction && len(args) != 1 {
+		return fmt.Errorf("wrong number of arguments")
+	}
+
+	// load configuration
+	tree, err := loadConfigFile(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	// print the config and exit
+	if len(args) == 0 {
+		s, err := tree.ToTomlString()
+		if err != nil {
+			return err
+		}
+		fmt.Print(s)
+		return nil
+	}
+
+	key := args[0]
+
+	// get config value for a given key
+	if getAction {
+		switch key {
+		case "trace", "trust-node", "indent":
+			fmt.Println(tree.GetDefault(key, false).(bool))
+
+		default:
+			if defaultValue, ok := configDefaults[key]; ok {
+				fmt.Println(tree.GetDefault(key, defaultValue).(string))
+				return nil
+			}
+
+			return errUnknownConfigKey(key)
+		}
+
+		return nil
+	}
+
+	if len(args) != 2 {
+		return fmt.Errorf("wrong number of arguments")
+	}
+
+	value := args[1]
+
+	// set config value for a given key
+	switch key {
+	case "chain-id", "output", "node", "broadcast-mode", "compiler":
+		tree.Set(key, value)
+
+	case "trace", "trust-node", "indent":
+		boolVal, err := strconv.ParseBool(value)
+		if err != nil {
+			return err
+		}
+
+		tree.Set(key, boolVal)
+
+	default:
+		return errUnknownConfigKey(key)
+	}
+
+	// save configuration to disk
+	if err := saveConfigFile(cfgFile, tree); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "configuration saved to %s\n", cfgFile)
+	return nil
+}
+
+func ensureConfFile(rootDir string) (string, error) {
+	cfgPath := path.Join(rootDir, "config")
+	if err := os.MkdirAll(cfgPath, os.ModePerm); err != nil {
+		return "", err
+	}
+
+	return path.Join(cfgPath, "config.toml"), nil
+}
+
+func loadConfigFile(cfgFile string) (*toml.Tree, error) {
+	if _, err := os.Stat(cfgFile); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "%s does not exist\n", cfgFile)
+		return toml.Load(``)
+	}
+
+	bz, err := ioutil.ReadFile(cfgFile)
+	if err != nil {
+		return nil, err
+	}
+
+	tree, err := toml.LoadBytes(bz)
+	if err != nil {
+		return nil, err
+	}
+
+	return tree, nil
+}
+
+func saveConfigFile(cfgFile string, tree *toml.Tree) error {
+	fp, err := os.OpenFile(cfgFile, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	_, err = tree.WriteTo(fp)
+	return err
+}
+
+func errUnknownConfigKey(key string) error {
+	return fmt.Errorf("unknown configuration key: %q", key)
+}

--- a/cmd/wbcli/main.go
+++ b/cmd/wbcli/main.go
@@ -45,7 +45,7 @@ func main() {
 	// Construct Root Command
 	rootCmd.AddCommand(
 		rpc.StatusCommand(),
-		client.ConfigCmd(app.DefaultCLIHome),
+		wbConfig.ConfigCmd(app.DefaultCLIHome),
 		queryCmd(cdc),
 		txCmd(cdc),
 		client.LineBreak,

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nntaoli-project/GoEx v1.0.11
-	github.com/pelletier/go-toml v1.6.0 // indirect
+	github.com/pelletier/go-toml v1.6.0
 	github.com/prometheus/client_golang v1.2.1 // indirect
 	github.com/prometheus/client_model v0.0.0-20191202183732-d1d2010b5bee // indirect
 	github.com/prometheus/procfs v0.0.8 // indirect


### PR DESCRIPTION
I replaced standard config of wbcli with our own. 
Now it's possible to set compiler via command line `wbcli config compiler <value>`, and i still supports `--compiler` argument in case of `compile-script` and `compile-module` commands.

E.g.:

```
wbcli config compiler 127.0.0.1:50053
wbcli config compiler --get
wbcli query vm compile-script <mvir> <address> --compiler 127.0.0.1:50053
```