### PR TITLE
Added jq to release container along with bash

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /opt/app
 ARG CI_PIPELINE_ID
 ARG CI_COMMIT_REF_NAME
 ARG CI_COMMIT_SHA
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates jq bash
 RUN echo "${CI_PIPELINE_ID}-${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHA}" > version
 COPY --from=build \
             /go/bin/dnode \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,19 +1,6 @@
 name: Tests & CrossBuild & DockerBuild
 
-# on: [push, pull_request]
-on:
-  push:
-    # branches:
-    #   - master
-    #   - feature-*
-    # tags:
-    #   - v[0-9]+.[0-9]+.[0-9]+
-  pull_request:
-  #   branches:
-  #     - master
-  #     - feature-*
-  #   tags:
-  #     - v[0-9]+.[0-9]+.[0-9]+
+on: [push]
 
 jobs:
   test-build:


### PR DESCRIPTION
To simplify genesis loading in testnet containers I suggest adding `jq` and `bash`. 