### PR TITLE
Remove mvir mentions

### DIFF
--- a/app/integ_test.go
+++ b/app/integ_test.go
@@ -43,18 +43,18 @@ func Test_ConsensusFailure(t *testing.T) {
 	ct.SetVMCompilerAddress("tcp://127.0.0.1:" + compilerPort)
 
 	senderAddr := ct.Accounts["validator1"].Address
-	mvirPath := path.Join(ct.RootDir, "script.mvir")
-	compiledPath := path.Join(ct.RootDir, "script.json")
+	movePath := path.Join(ct.RootDir, "script.move")
+	compiledPath := path.Join(ct.RootDir, "script.move.json")
 
-	// Create .mvir script file
-	mvirFile, err := os.Create(mvirPath)
+	// Create .move script file
+	moveFile, err := os.Create(movePath)
 	require.NoError(t, err, "creating script file")
-	_, err = mvirFile.WriteString(script)
+	_, err = moveFile.WriteString(script)
 	require.NoError(t, err, "write script file")
-	require.NoError(t, mvirFile.Close(), "close script file")
+	require.NoError(t, moveFile.Close(), "close script file")
 
-	// Compile .mvir script file
-	ct.QueryVmCompileScript(mvirPath, compiledPath, senderAddr).CheckSucceeded()
+	// Compile .move script file
+	ct.QueryVmCompileScript(movePath, compiledPath, senderAddr).CheckSucceeded()
 
 	// Execute .json script file
 	// Should panic as there is no local VM running
@@ -123,18 +123,18 @@ func Test_VMExecuteScript(t *testing.T) {
 	defer executorContainer.Stop()
 
 	senderAddr := ct.Accounts["validator1"].Address
-	mvirPath := path.Join(ct.RootDir, "script.mvir")
-	compiledPath := path.Join(ct.RootDir, "script.json")
+	movePath := path.Join(ct.RootDir, "script.move")
+	compiledPath := path.Join(ct.RootDir, "script.move.json")
 
-	// Create .mvir script file
-	mvirFile, err := os.Create(mvirPath)
+	// Create .move script file
+	moveFile, err := os.Create(movePath)
 	require.NoError(t, err, "creating script file")
-	_, err = mvirFile.WriteString(script)
+	_, err = moveFile.WriteString(script)
 	require.NoError(t, err, "write script file")
-	require.NoError(t, mvirFile.Close(), "close script file")
+	require.NoError(t, moveFile.Close(), "close script file")
 
-	// Compile .mvir script file
-	ct.QueryVmCompileScript(mvirPath, compiledPath, senderAddr).CheckSucceeded()
+	// Compile .move script file
+	ct.QueryVmCompileScript(movePath, compiledPath, senderAddr).CheckSucceeded()
 
 	// Execute .json script file
 	ct.TxVmExecuteScript(senderAddr, compiledPath).CheckSucceeded()

--- a/docs/vm.md
+++ b/docs/vm.md
@@ -61,7 +61,7 @@ into storage.
 
 So, first of all, go to VM folder, and run:
 
-    cargo run --bin stdlib-builder stdlib/mvir mvir -po ../genesis-ws.json
+    cargo run --bin stdlib-builder lang/stdlib -po ./genesis-ws.json
 
 After this, go into DN folder and run:
 
@@ -75,14 +75,14 @@ Launch compiler server, and DN.
 
 Then use commands to compile modules/scripts:
 
-    dncli query vm compile-script [mvirFile] [address] --to-file <script.mv> --compiler 127.0.0.1:50053
-    dncli query vm compile-module [mvirFile] [address] --to-file <module.mv> --compiler 127.0.0.1:50053    
+    dncli query vm compile-script [moveFile] [address] --to-file <script.move.json>
+    dncli query vm compile-module [moveFile] [address] --to-file <module.move.json>  
 
 Where:
- * `mvirFile` - file contains MVir code.
+ * `moveFile` - file contains Move code.
  * `address` - address of account who will use compiled code.
  * `--to-file` - allows to output result to file, otherwise it will be printed in console.
- * `--compiler` - address of compiler, could be ignored, default is `127.0.0.1:50053`.
+ * `--compiler` - address of compiler, could be ignored, default is `tcp://127.0.0.1:50053`.
 
 ## Configuration
 
@@ -99,16 +99,28 @@ later it will be changed for stability), `vm.toml` contains such default paramet
 ##### main base config options #####
 
 # VM network address to connect.
-vm_address = "127.0.0.1:50051"
+vm_address = "tcp://127.0.0.1:50051"
 
 # VM data server listen address.
-vm_data_listen = "127.0.0.1:50052"
+vm_data_listen = "tpc://127.0.0.1:50052
 
-# VM deploy request timeout in milliseconds.
-vm_deploy_timeout = 100
+# VM retry settings.
 
-# VM execute contract request timeout in milliseconds.
-vm_execute_timeout = 100
+## Retry max attempts.
+## Default is 0 - infinity attempts, -1 - to desable.
+vm_retry_max_attempts = 0
+
+## Initial backoff in ms.
+## Default is 100ms.
+vm_retry_initial_backoff = 100
+
+## Max backoff in ms.
+## Default is 150ms.
+vm_retry_max_backoff = 150
+
+## Backoff multiplier.
+## Default 
+vm_retry_backoff_multiplier = 0.1
 ```
 
 Where:
@@ -116,7 +128,7 @@ Where:
 * `vm_address` - address of GRPC VM node contains Move VM, using to deploy/execute modules.
 * `vm_data_listen` - address to listen for GRPC Data Source server (part of DN), using to share data between DN and VM.
 
-The rest parameters are timeouts, don't recommend to change it.
+The rest parameters are timeouts and retry mechanism, don't recommend to change it.
 
 ## Get storage data
 

--- a/helpers/tests/clitester/cli_tester_queries.go
+++ b/helpers/tests/clitester/cli_tester_queries.go
@@ -131,9 +131,9 @@ func (ct *CLITester) QueryMultiLastId() (*QueryRequest, *msTypes.LastIdRes) {
 	return q, resObj
 }
 
-func (ct *CLITester) QueryVmCompileScript(mvirFilePath, savePath, accountAddress string) *QueryRequest {
+func (ct *CLITester) QueryVmCompileScript(moveFilePath, savePath, accountAddress string) *QueryRequest {
 	q := ct.newQueryRequest(nil)
-	q.SetCmd("vm", "compile-script", mvirFilePath, accountAddress)
+	q.SetCmd("vm", "compile-script", moveFilePath, accountAddress)
 	q.cmd.AddArg("compiler", ct.vmCompilerAddress)
 	q.cmd.AddArg("to-file", savePath)
 

--- a/x/vm/client/cli/queries.go
+++ b/x/vm/client/cli/queries.go
@@ -47,8 +47,8 @@ func GetQueryCmd(cdc *amino.Codec) *cobra.Command {
 	return queryCmd
 }
 
-// Read mvir file by file path.
-func readMvirFile(filePath string) ([]byte, error) {
+// Read move file by file path.
+func readMoveFile(filePath string) ([]byte, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ func saveOutput(bytecode []byte, cdc *codec.Codec) error {
 	code := hex.EncodeToString(bytecode)
 	output := viper.GetString(vmClient.FlagOutput)
 
-	mvFile := vmClient.MVFile{Code: code}
+	mvFile := vmClient.MoveFile{Code: code}
 	mvBytes, err := cdc.MarshalJSONIndent(mvFile, "", "    ")
 	if err != nil {
 		return err
@@ -135,20 +135,20 @@ func GetData(queryRoute string, cdc *codec.Codec) *cobra.Command {
 	}
 }
 
-// Compile Mvir script.
+// Compile Move script.
 func CompileScript(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:     "compile-script [mvirFile] [account]",
-		Short:   "compile script using source code from mvir file",
-		Example: "compile-script script.mvir wallet196udj7s83uaw2u4safcrvgyqc0sc3flxuherp6 --to-file script.mvir.json",
+		Use:     "compile-script [moveFile] [account]",
+		Short:   "compile script using source code from Move file",
+		Example: "compile-script script.move wallet196udj7s83uaw2u4safcrvgyqc0sc3flxuherp6 --to-file script.move.json",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			compilerAddr := viper.GetString(vmClient.FlagCompilerAddr)
 
 			// read provided file
-			mvirContent, err := readMvirFile(args[0])
+			moveContent, err := readMoveFile(args[0])
 			if err != nil {
-				return fmt.Errorf("error during reading mvir file %q: %v", args[0], err)
+				return fmt.Errorf("error during reading Move file %q: %v", args[0], err)
 			}
 
 			addr, err := sdk.AccAddressFromBech32(args[1])
@@ -156,14 +156,14 @@ func CompileScript(cdc *codec.Codec) *cobra.Command {
 				return fmt.Errorf("error during parsing address %s: %v", args[1], err)
 			}
 
-			// Mvir file
+			// Move file
 			sourceFile := &vm_grpc.MvIrSourceFile{
-				Text:    string(mvirContent),
+				Text:    string(moveContent),
 				Address: common_vm.Bech32ToLibra(addr),
 				Type:    vm_grpc.ContractType_Script,
 			}
 
-			// compile mvir file
+			// compile Move file
 			bytecode, err := vmClient.Compile(compilerAddr, sourceFile)
 			if err != nil {
 				return err
@@ -180,20 +180,20 @@ func CompileScript(cdc *codec.Codec) *cobra.Command {
 	}
 }
 
-// Compile Mvir module.
+// Compile Move module.
 func CompileModule(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:     "compile-module [mvirFile] [account]",
-		Short:   "compile module connected to account, using source code from mvir file",
-		Example: "compile-module module.mvir wallet196udj7s83uaw2u4safcrvgyqc0sc3flxuherp6 --to-file module.mvir.json",
+		Use:     "compile-module [moveFile] [account]",
+		Short:   "compile module connected to account, using source code from Move file",
+		Example: "compile-module module.move wallet196udj7s83uaw2u4safcrvgyqc0sc3flxuherp6 --to-file module.move.json",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			compilerAddr := viper.GetString(vmClient.FlagCompilerAddr)
 
 			// read provided file
-			mvirContent, err := readMvirFile(args[0])
+			moveContent, err := readMoveFile(args[0])
 			if err != nil {
-				return fmt.Errorf("error during reading mvir file %q: %v", args[0], err)
+				return fmt.Errorf("error during reading Move file %q: %v", args[0], err)
 			}
 
 			addr, err := sdk.AccAddressFromBech32(args[1])
@@ -201,14 +201,14 @@ func CompileModule(cdc *codec.Codec) *cobra.Command {
 				return fmt.Errorf("error during parsing address %s: %v", args[1], err)
 			}
 
-			// Mvir file
+			// Move file
 			sourceFile := &vm_grpc.MvIrSourceFile{
-				Text:    string(mvirContent),
+				Text:    string(moveContent),
 				Address: common_vm.Bech32ToLibra(addr),
 				Type:    vm_grpc.ContractType_Module,
 			}
 
-			// compile mvir file
+			// compile Move file
 			bytecode, err := vmClient.Compile(compilerAddr, sourceFile)
 			if err != nil {
 				return err

--- a/x/vm/client/cli/tx.go
+++ b/x/vm/client/cli/tx.go
@@ -48,34 +48,34 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 	return txCmd
 }
 
-// Read MVir file contains code in hex.
-func GetMVFromFile(filePath string) (vmClient.MVFile, error) {
-	var mvir vmClient.MVFile
+// Read Move file contains code in hex.
+func GetMVFromFile(filePath string) (vmClient.MoveFile, error) {
+	var move vmClient.MoveFile
 
 	file, err := os.Open(filePath)
 	if err != nil {
-		return mvir, err
+		return move, err
 	}
 	defer file.Close()
 
 	jsonContent, err := ioutil.ReadAll(file)
 	if err != nil {
-		return mvir, err
+		return move, err
 	}
 
-	if err := json.Unmarshal(jsonContent, &mvir); err != nil {
-		return mvir, err
+	if err := json.Unmarshal(jsonContent, &move); err != nil {
+		return move, err
 	}
 
-	return mvir, nil
+	return move, nil
 }
 
 // Execute script contract.
 func ExecuteScript(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:     "execute-script [compileMvir] [arg1,arg2,arg3,...]",
+		Use:     "execute-script [compileMove] [arg1,arg2,arg3,...]",
 		Short:   "execute Move script",
-		Example: "execute-script ./script.mvir.json wallet1jk4ld0uu6wdrj9t8u3gghm9jt583hxx7xp7he8 100 true \"my string\" \"68656c6c6f2c20776f726c6421\" #\"DFI_ETH\"",
+		Example: "execute-script ./script.move.json wallet1jk4ld0uu6wdrj9t8u3gghm9jt583hxx7xp7he8 100 true \"my string\" \"68656c6c6f2c20776f726c6421\" #\"DFI_ETH\"",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			compilerAddr := viper.GetString(vmClient.FlagCompilerAddr)
@@ -210,7 +210,7 @@ func DeployContract(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:     "deploy-module [mvFile]",
 		Short:   "deploy Move contract",
-		Example: "deploy-module ./my_module.mvir.json",
+		Example: "deploy-module ./my_module.move.json",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inBuf := bufio.NewReader(cmd.InOrStdin())

--- a/x/vm/client/compiler.go
+++ b/x/vm/client/compiler.go
@@ -19,7 +19,7 @@ const (
 )
 
 // MVFile struct contains code from file in hex.
-type MVFile struct {
+type MoveFile struct {
 	Code string `json:"code"`
 }
 

--- a/x/vm/client/rest/rest.go
+++ b/x/vm/client/rest/rest.go
@@ -87,7 +87,7 @@ func commonCompileHandler(cliCtx context.CLIContext, compileType vm_grpc.Contrac
 			return
 		}
 
-		resp := vmClient.MVFile{
+		resp := vmClient.MoveFile{
 			Code: hex.EncodeToString(byteCode),
 		}
 		rest.PostProcessResponse(w, cliCtx, resp)

--- a/x/vm/client/rest/swagger.go
+++ b/x/vm/client/rest/swagger.go
@@ -8,8 +8,8 @@ import (
 //nolint:deadcode,unused
 type (
 	VmRespCompile struct {
-		Height int64           `json:"height"`
-		Result vmClient.MVFile `json:"result"`
+		Height int64             `json:"height"`
+		Result vmClient.MoveFile `json:"result"`
 	}
 
 	VmData struct {

--- a/x/vm/internal/keeper/keeper_integ_test.go
+++ b/x/vm/internal/keeper/keeper_integ_test.go
@@ -302,7 +302,7 @@ func TestKeeper_DeployModule(t *testing.T) {
 
 	checkNoErrors(events, t)
 
-	require.Equal(t, events[1].Type, types.EventTypeMvirEvent, "script after execution doesn't contain event with amount")
+	require.Equal(t, events[1].Type, types.EventTypeMoveEvent, "script after execution doesn't contain event with amount")
 
 	require.Len(t, events[1].Attributes, 4)
 	require.EqualValues(t, events[1].Attributes[1].Key, types.AttrKeySequenceNumber)

--- a/x/vm/internal/keeper/keeper_integ_test.go
+++ b/x/vm/internal/keeper/keeper_integ_test.go
@@ -128,11 +128,17 @@ func TestKeeper_DeployContractTransfer(t *testing.T) {
 		sdk.NewCoin("usdt", baseAmount),
 	)
 
+	denoms := make([]string, 4)
+	denoms[0] = "dfi"
+	denoms[1] = "eth"
+	denoms[2] = "btc"
+	denoms[3] = "usdt"
+
 	toSend := make(map[string]sdk.Int, 4)
-	toSend["dfi"] = sdk.NewInt(100)
-	toSend["eth"] = sdk.NewInt(90)
-	toSend["btc"] = sdk.NewInt(80)
-	toSend["usdt"] = sdk.NewInt(70)
+
+	for i := 0; i < len(denoms); i++ {
+		toSend[denoms[i]] = sdk.NewInt(100 - int64(i)*10)
+	}
 
 	acc1.SetCoins(putCoins)
 
@@ -178,9 +184,9 @@ func TestKeeper_DeployContractTransfer(t *testing.T) {
 		Type:  vm_grpc.VMTypeTag_Address,
 	}
 
-	for _, value := range toSend {
+	for _, d := range denoms {
 		args = append(args, types.ScriptArg{
-			Value: value.String(),
+			Value: toSend[d].String(),
 			Type:  vm_grpc.VMTypeTag_U128,
 		})
 	}

--- a/x/vm/internal/types/events.go
+++ b/x/vm/internal/types/events.go
@@ -12,7 +12,7 @@ import (
 const (
 	// Event types.
 	EventTypeContractStatus = "contract_status"
-	EventTypeMvirEvent      = "contract_events"
+	EventTypeMoveEvent      = "contract_events"
 
 	// Attributes keys
 	AttrKeyStatus         = "status"
@@ -68,7 +68,7 @@ func NewEventDiscard(errorStatus *vm_grpc.VMStatus) sdk.Event {
 // In case of event data equal "struct" we don't process struct, and just keep bytes, as for any other type.
 func NewEventFromVM(event *vm_grpc.VMEvent) sdk.Event {
 	return sdk.NewEvent(
-		EventTypeMvirEvent,
+		EventTypeMoveEvent,
 		sdk.NewAttribute(AttrKeyGuid, "0x"+hex.EncodeToString(event.Key)),
 		sdk.NewAttribute(AttrKeySequenceNumber, strconv.FormatUint(event.SequenceNumber, 10)),
 		sdk.NewAttribute(AttrKeyType, VMTypeToStringPanic(event.Type.Tag)),

--- a/x/vm/internal/types/events_test.go
+++ b/x/vm/internal/types/events_test.go
@@ -80,7 +80,7 @@ func TestNewEventFromVM(t *testing.T) {
 	}
 
 	event := NewEventFromVM(&vmEvent)
-	require.Equal(t, EventTypeMvirEvent, event.Type)
+	require.Equal(t, EventTypeMoveEvent, event.Type)
 	require.Len(t, event.Attributes, 4)
 
 	require.EqualValues(t, AttrKeyGuid, event.Attributes[0].Key)


### PR DESCRIPTION
Removed mvir mentions from code/comments. 
Also, new helps and examples for `tx vm` commands, e.g.:

```shell
dncli tx vm execute-script --help 
dncli tx vm deploy-module --help
```